### PR TITLE
Fix 404 error when JS were in the same folder as .html

### DIFF
--- a/src/jstack/js/JStack.hx
+++ b/src/jstack/js/JStack.hx
@@ -93,7 +93,8 @@ class JStack {
      * Do the job in browser environment
      */
     function loadInBrowser (callback:String->Void) {
-        var file = getCurrentDirInBrowser() + '/' + Tools.getSourceMapFileName();
+        var currDir = getCurrentDirInBrowser();
+        var file = currDir != null ? currDir + '/' + Tools.getSourceMapFileName() : Tools.getSourceMapFileName();
         var http = new Http(file);
 
         http.onError = function (error:String) {


### PR DESCRIPTION
Hello there!
I was trying to use your awesome lib but I was getting:
```
GET http://localhost:2000/null/CallStack.js.map 404 (Not Found)
Http Error #404
```

After quick digging I think I found the issue. My JS file was in same folder as .html file and looks like `JStack.hx` class was assuming that there's always gonna be `getCurrentDirInBrowser()`. Fixing that by adding simple check.